### PR TITLE
Ecommerce/tests

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/intercom/IntercomIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/intercom/IntercomIntegration.java
@@ -163,6 +163,13 @@ public class IntercomIntegration extends Integration<Void> {
       if (!isNullOrEmpty(price)) {
         propertiesCopy.put(PRICE, price);
       }
+      for (Map.Entry<String, Object> entry : realProperties.entrySet()) {
+        String key = entry.getKey();
+        Object value = entry.getValue();
+        if (key.equals("products") || value instanceof Map) {
+          propertiesCopy.remove(key);
+        }
+      }
       intercom.logEvent(eventName, propertiesCopy);
       logger.verbose("Intercom.client().logEvent(%s, %s)", eventName, propertiesCopy);
       return;
@@ -235,14 +242,12 @@ public class IntercomIntegration extends Integration<Void> {
         userAttributes.withUnsubscribedFromEmails(unsubscribedFromEmails);
       }
     }
-
     if (traitsCopy.containsKey(COMPANY) && traitsCopy.get(COMPANY) instanceof Map) {
       Map<String, Object> companyObj = (HashMap<String, Object>) traitsCopy.get(COMPANY);
       Company company = setCompany(companyObj);
       userAttributes.withCompany(company);
       traitsCopy.remove(COMPANY);
     }
-
     for (Map.Entry<String, Object> entry : traitsCopy.entrySet()) {
       String trait = entry.getKey();
       Object value = entry.getValue();

--- a/src/test/java/com/segment/analytics/android/integration/intercom/IntercomTest.java
+++ b/src/test/java/com/segment/analytics/android/integration/intercom/IntercomTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.rule.PowerMockRule;
@@ -34,6 +34,7 @@ import java.util.Map;
 import io.intercom.android.sdk.Intercom;
 import io.intercom.android.sdk.UserAttributes;
 import io.intercom.android.sdk.identity.Registration;
+
 import static com.segment.analytics.Analytics.LogLevel.VERBOSE;
 import static com.segment.analytics.Utils.createTraits;
 import static org.junit.Assert.assertEquals;
@@ -66,11 +67,11 @@ public class IntercomTest {
                 .putValue("mobileApiKey", "123")
                 .putValue("appId", "123"),
                 Logger.with(VERBOSE));
-        Mockito.reset(intercom);
     }
 
     @Test
     public void initialize() {
+        PowerMockito.mockStatic(Intercom.class);
         integration = new IntercomIntegration(mockProvider, application, new ValueMap()
                 .putValue("mobileApiKey", "123")
                 .putValue("appId", "123"),


### PR DESCRIPTION
Fixes issue with initialize test. Also uses specced ecommerce event format in tests. Guards against passing nested products collection or nested object in a track call. I'm planning to guard against nested traits in identify and group in a separate PR.