### PR TITLE
Register unidentified user on init and reset

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/intercom/IntercomIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/intercom/IntercomIntegration.java
@@ -98,6 +98,9 @@ public class IntercomIntegration extends Integration<Intercom> {
     Intercom.initialize(application, mobileApiKey, appId);
     this.intercom = provider.get();
     this.logger = logger;
+ 
+    this.intercom.registerUnidentifiedUser();
+    logger.verbose("Intercom.client().registerUnidentifiedUser()");
   }
 
   @Override
@@ -199,6 +202,9 @@ public class IntercomIntegration extends Integration<Intercom> {
     super.reset();
     intercom.logout();
     logger.verbose("Intercom.client().reset()");
+
+    intercom.registerUnidentifiedUser();
+    logger.verbose("Intercom.client().registerUnidentifiedUser()");
   }
 
   @Override


### PR DESCRIPTION
Trying to open an intercom chat (`Intercom.client().displayMessageComposer();`) without being logged in leads to an error since Intercom ALWAYS requires the user to be identified.
Luckily intercom offers the `registerUnidentifiedUser ` method.

Looking at the current Intercom integration this method is also included:
https://github.com/segment-integrations/analytics-android-integration-intercom/blob/master/src/main/java/com/segment/analytics/android/integrations/intercom/IntercomIntegration.java#L110

Unfortunately this method never seems to be called since an identify call with the segment SDK ALWAYS requires a user. So the `if (isNullOrEmpty(userId))` where`registerUnidentifiedUser ` would be called is never reached.

This pull requests changes this behavior and ALWAYS ensures that intercom has either an unregistered user (set within init and reset method) or a registered one (set in identify).
This way the intercom chat can still be shown even though the user has not identified before.

NOTE:
I applied the same changes to the ios integration: https://github.com/segment-integrations/analytics-ios-integration-intercom/pull/7