### PR TITLE
Migrate project to AndroidX

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,6 @@ dependencies {
 
   implementation 'androidx.appcompat:appcompat:1.2.0'
   implementation 'androidx.annotation:annotation:1.2.0'
-  implementation 'com.android.support:support-annotations:28.0.0'
 
 //  Test dependencies
   testImplementation 'junit:junit:4.12'

--- a/src/main/java/com/segment/analytics/android/integrations/intercom/IntercomIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/intercom/IntercomIntegration.java
@@ -1,7 +1,7 @@
 package com.segment.analytics.android.integrations.intercom;
 
 import android.app.Application;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.segment.analytics.Analytics;
 import com.segment.analytics.Properties;


### PR DESCRIPTION
No need to keep `support-annotations` anymore as `androidx.annotations` offer the same set of annotations.

Will resolve issues like this one:
```
-> com.segment.analytics.android.integrations:intercom:1.3.0 -> com.android.support:support-annotations:28.0.0
WARNING:Your project has set `android.useAndroidX=true`, but configuration `:somemodule:implementation:releaseRuntimeClasspath` still contains legacy support libraries, which may cause runtime issues.
This behavior will not be allowed in Android Gradle plugin 8.0.
```
