### PR TITLE
Prepare release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 1.4.0 (14th March, 2023)
+==================================
+* Bumps Analytics version from 4.0.0 to 4.11.1
+* Bumps Intercom SDK from 9.1.2 to 14.0.4
+* Get ride of Support annotations and appcompat libs
+
 Version 1.3.0 (3rd May, 2021)
 ==================================
   * Bumps Intercom SDK from 6.0.1 to 9.1.2

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,13 @@
 buildscript {
   repositories {
     mavenCentral()
-    jcenter()
     google()
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.4.0'
+    classpath 'com.android.tools.build:gradle:3.4.3'
     classpath 'com.f2prateek.javafmt:javafmt:0.1.6'
-    classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.11.0'
+    classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.22.0'
   }
 }
 
@@ -19,13 +18,13 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.f2prateek.javafmt'
 
 android {
-  compileSdkVersion 26
-  buildToolsVersion '28.0.3'
+  compileSdkVersion 33
+  buildToolsVersion '33.0.1'
 
   defaultConfig {
     minSdkVersion 21
-    targetSdkVersion 26
-    compileSdkVersion 26
+    targetSdkVersion 33
+    compileSdkVersion 33
   }
 
   compileOptions {
@@ -45,15 +44,14 @@ android {
 dependencies {
   repositories {
     mavenCentral()
-    jcenter()
     google()
   }
 
-  implementation 'com.segment.analytics.android:analytics:4.0.0'
+  implementation 'com.segment.analytics.android:analytics:4.11.1'
   testImplementation 'com.segment.analytics.android:analytics-tests:4.2.6'
 
-  implementation 'io.intercom.android:intercom-sdk-base:9.1.2'
-  implementation 'io.intercom.android:intercom-sdk-fcm:9.1.2'
+  implementation 'io.intercom.android:intercom-sdk-base:14.0.4'
+  implementation 'io.intercom.android:intercom-sdk-fcm:14.0.4'
 
   implementation 'androidx.appcompat:appcompat:1.2.0'
   implementation 'androidx.annotation:annotation:1.2.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.integrations
 
-VERSION=1.3.1-SNAPSHOT
+VERSION=1.4.0-SNAPSHOT
 
 POM_ARTIFACT_ID=intercom
 POM_PACKAGING=aar


### PR DESCRIPTION
* Bumps Analytics version from 4.0.0 to 4.11.1
* Bumps Intercom SDK from 9.1.2 to 14.0.4
* Get ride of Support annotations and appcompat libs